### PR TITLE
ディスク切断の順序変更

### DIFF
--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -169,13 +169,13 @@ func (m *Migration) applyServer(status *ServerStatus) {
 		return
 	}
 
-	// disconnect disk
-	if err := m.handleSteps(m.disconnectDisks, status, status.stepDisconnectDisks); err != nil {
+	// clone disk
+	if err := m.handleSteps(m.cloneDisks, status, status.cloneDiskSteps()...); err != nil {
 		return
 	}
 
-	// clone disk
-	if err := m.handleSteps(m.cloneDisks, status, status.cloneDiskSteps()...); err != nil {
+	// disconnect disk
+	if err := m.handleSteps(m.disconnectDisks, status, status.stepDisconnectDisks); err != nil {
 		return
 	}
 


### PR DESCRIPTION
現在はディスクの切断 -> ディスクのコピー作成をおこなっている。

この場合、ディスクのコピーをキャンセルしたり、API呼び出し時にエラーが発生した場合、
操作対象のサーバにはディスクが接続されていないことになる。
この状態だとマイグレーションの再実行を行うには手動でディスクをサーバに接続する必要がある。

これを処理の順序を逆にすることでディスクの切断が行われている状態を最小限にし、エラー発生時の再実行を容易にする。